### PR TITLE
Add unsubscribe

### DIFF
--- a/sse.py
+++ b/sse.py
@@ -95,6 +95,35 @@ class Publisher(object):
 
         return self._make_generator(queue)
 
+    def unsubscribe(self, channel='default channel', properties=None):
+        """
+        `channel` can either be a channel name (e.g. "secret room") or a list
+        of channel names (e.g. "['chat', 'global messages']"). It defaults to
+        the channel named "default channel".
+        If `properties` is None, then all subscribers will be removed from selected
+        channel(s). If properties are provided then these are used to filter which
+        subscribers are removed. Only the subscribers exactly matching the properties
+        are unsubscribed.
+        """
+
+        if properties is None:
+            if isinstance(channel, str):
+                self.subscribers_by_channel[channel] = []
+            else:
+                for channel_name in channel:
+                    self.subscribers_by_channel[channel_name] = []
+
+        else:
+            if isinstance(channel, str):
+                self.subscribers_by_channel[channel] = [
+                    x for x in self.subscribers_by_channel[channel]
+                    if x[1] != properties]
+            else:
+                for channel_name in channel:
+                    self.subscribers_by_channel[channel_name] = [
+                        x for x in self.subscribers_by_channel[channel_name]
+                        if x[1] != properties]
+
     def _make_generator(self, queue):
         """
         Returns a generator that reads data from the queue, emitting data

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,7 @@
 import unittest
 from sse import Publisher
 
+
 class TestPublisher(unittest.TestCase):
     def read(self, generator):
         return ''.join(generator).strip()
@@ -48,6 +49,25 @@ class TestPublisher(unittest.TestCase):
         self.assertEqual(self.read(s1), 'data: 1')
         self.assertEqual(self.read(s2), 'data: 2')
 
+    def test_unsubscribe(self):
+        p = Publisher()
+        self.assertEqual(len(p.subscribers_by_channel['default channel']), 0)
+
+        p.subscribe(properties=1)
+        p.subscribe(properties=2)
+        self.assertEqual(len(p.subscribers_by_channel['default channel']), 2)
+
+        p.unsubscribe(properties=2)
+        self.assertEqual(len(p.subscribers_by_channel['default channel']), 1)
+
+        p.subscribe(properties={'id': 3, 'eggs': 'spam'})
+        self.assertEqual(len(p.subscribers_by_channel['default channel']), 2)
+
+        p.unsubscribe(properties={'id': 3, 'eggs': 'spam'})
+        self.assertEqual(len(p.subscribers_by_channel['default channel']), 1)
+
+        p.close()
+
     def test_initial_data(self):
         p = Publisher()
         s = p.subscribe(initial_data=['start 1', 'start 2'])
@@ -64,6 +84,7 @@ class TestPublisher(unittest.TestCase):
         p.publish('line 1\nline 2')
         p.close()
         self.assertEqual(self.read(s), 'data: line 1\ndata: line 2')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I am aware that this code base is already several years old. I wanted to ask anyway...

I noticed that the `Publisher` does not have a way to `unsubscribe` a `subscriber`. 

Maybe I overlooked/misunderstood something fundamental about how this should be used. But as far as I see it, the ability to `unsubscribe` one (or all) `subscribers` from one (or all) `channels` makes sense. I added a sample implementation in this PR - would you be so kind to give me some feedback on this?